### PR TITLE
Add Save / Cancel actions

### DIFF
--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -150,8 +150,6 @@ class ActionFactory:
         definition['action'].append({
             'name': 'save',
             'string': _('Save'),
-            'report_name': 'printscreen.list',
-            'type': 'ir.actions.report.xml'
         })
 
         actions = []

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -133,7 +133,6 @@ class ActionFactory:
             # If definition is not set we initialize it appropiately
             # to be able to add the 'Print Screen' action.
             definition = {
-                'save': [],
                 'print': [],
                 'action': [],
                 'relate': []
@@ -147,24 +146,16 @@ class ActionFactory:
             'type': 'ir.actions.report.xml'
         })
 
-        # Save as new definition
-        definition['save'] = [{
-            'name': 'Save changes',
-            'string': _('Save'),
-            'report_name': 'printscreen.list',
-            'type': 'ir.actions.report.xml'
-        }]
-
         # Save as action
         definition['action'].append({
             'name': 'save',
-            'string': _('Save as action'),
+            'string': _('Save'),
             'report_name': 'printscreen.list',
             'type': 'ir.actions.report.xml'
         })
 
         actions = []
-        for icontype in ('print', 'action', 'relate', 'save'):
+        for icontype in ('print', 'action', 'relate'):
             for tool in definition[icontype]:
                 action = Action(parent)
                 action.setIcon(QIcon(":/images/%s.png" % icontype))

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -184,6 +184,15 @@ class ActionFactory:
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
                     action.setIcon(QIcon(":/images/save.png"))
 
+                else:
+                    if number > 9:
+                        shortcut += 'Shift+'
+                        number -= 10
+                    if number < 10:
+                        shortcut += str(number)
+                        action.setShortcut(QKeySequence(shortcut))
+                        action.setToolTip(action.text() + ' (%s)' % shortcut)
+
 
                 actions.append(action)
 

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -182,6 +182,8 @@ class ActionFactory:
                     shortcut += "S"
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
+                    action.setIcon(QIcon(":/images/save.png"))
+
 
                 actions.append(action)
 

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -173,6 +173,8 @@ class ActionFactory:
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
                     action.setIcon(QIcon(":/images/save.png"))
 
+                    action.triggered.connect(parent.save)
+
                 else:
                     if number > 9:
                         shortcut += 'Shift+'

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -174,12 +174,12 @@ class ActionFactory:
                 action.setModel(model)
 
                 number = len(actions)
+
                 shortcut = 'Ctrl+'
-                if number > 9:
-                    shortcut += 'Shift+'
-                    number -= 10
-                if number < 10:
-                    shortcut += str(number)
+
+                # Add save shortcut with Ctrl + S
+                if tool['name'] == "save":
+                    shortcut += "S"
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
 

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -146,10 +146,16 @@ class ActionFactory:
             'type': 'ir.actions.report.xml'
         })
 
-        # Save as action
+        # Save action
         definition['action'].append({
             'name': 'save',
             'string': _('Save'),
+        })
+
+        # Save action
+        definition['action'].append({
+            'name': 'cancel',
+            'string': _('Cancel'),
         })
 
         actions = []
@@ -167,12 +173,11 @@ class ActionFactory:
                 shortcut = 'Ctrl+'
 
                 # Add save shortcut with Ctrl + S
-                if tool['name'] == "save":
+                if tool['name'] in ["save", "cancel"]:
                     shortcut += "S"
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
                     action.setIcon(QIcon(":/images/save.png"))
-
                     action.triggered.connect(parent.save)
 
                 else:

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -159,7 +159,7 @@ class ActionFactory:
             'name': 'cancel',
             'string': _('Cancel'),
             'shortcut': 'C',
-            'action': parent.cancel,
+            'action': parent.parentWidget().cancel,
         })
 
         actions = []

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -179,7 +179,7 @@ class ActionFactory:
                     shortcut += tool['shortcut']
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
-                    action.setIcon(QIcon(":/images/save.png"))
+                    action.setIcon(QIcon(":/images/{}.png".format(tool['name'])))
                     action.triggered.connect(parent.save)
 
                 else:

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -151,13 +151,15 @@ class ActionFactory:
             'name': 'save',
             'string': _('Save'),
             'shortcut': 'S',
+            'action': parent.save,
         })
 
-        # Save action
+        # Cancel action
         definition['action'].append({
             'name': 'cancel',
             'string': _('Cancel'),
             'shortcut': 'C',
+            'action': parent.cancel,
         })
 
         actions = []
@@ -180,7 +182,7 @@ class ActionFactory:
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
                     action.setIcon(QIcon(":/images/{}.png".format(tool['name'])))
-                    action.triggered.connect(parent.save)
+                    action.triggered.connect(tool['action'])
 
                 else:
                     if number > 9:

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -147,13 +147,21 @@ class ActionFactory:
             'type': 'ir.actions.report.xml'
         })
 
-        # We always add the 'Print Screen' action.
+        # Save as new definition
         definition['save'] = [{
             'name': 'Save changes',
             'string': _('Save'),
             'report_name': 'printscreen.list',
             'type': 'ir.actions.report.xml'
         }]
+
+        # Save as action
+        definition['action'].append({
+            'name': 'save',
+            'string': _('Save as action'),
+            'report_name': 'printscreen.list',
+            'type': 'ir.actions.report.xml'
+        })
 
         actions = []
         for icontype in ('print', 'action', 'relate', 'save'):

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -150,12 +150,14 @@ class ActionFactory:
         definition['action'].append({
             'name': 'save',
             'string': _('Save'),
+            'shortcut': 'S',
         })
 
         # Save action
         definition['action'].append({
             'name': 'cancel',
             'string': _('Cancel'),
+            'shortcut': 'C',
         })
 
         actions = []
@@ -174,7 +176,7 @@ class ActionFactory:
 
                 # Add save shortcut with Ctrl + S
                 if tool['name'] in ["save", "cancel"]:
-                    shortcut += "S"
+                    shortcut += tool['shortcut']
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
                     action.setIcon(QIcon(":/images/save.png"))

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -133,6 +133,7 @@ class ActionFactory:
             # If definition is not set we initialize it appropiately
             # to be able to add the 'Print Screen' action.
             definition = {
+                'save': [],
                 'print': [],
                 'action': [],
                 'relate': []
@@ -146,8 +147,16 @@ class ActionFactory:
             'type': 'ir.actions.report.xml'
         })
 
+        # We always add the 'Print Screen' action.
+        definition['save'] = [{
+            'name': 'Save changes',
+            'string': _('Save'),
+            'report_name': 'printscreen.list',
+            'type': 'ir.actions.report.xml'
+        }]
+
         actions = []
-        for icontype in ('print', 'action', 'relate'):
+        for icontype in ('print', 'action', 'relate', 'save'):
             for tool in definition[icontype]:
                 action = Action(parent)
                 action.setIcon(QIcon(":/images/%s.png" % icontype))
@@ -167,6 +176,7 @@ class ActionFactory:
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
 
                 actions.append(action)
+
 
         plugs = Plugins.list(model)
         for p in sorted(list(plugs.keys()), key=lambda x: plugs[x].get('string', '')):

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -151,7 +151,7 @@ class ActionFactory:
             'name': 'save',
             'string': _('Save'),
             'shortcut': 'S',
-            'action': parent.save,
+            'action': parent.parentWidget().save,
         })
 
         # Cancel action

--- a/Koo/Screen/Screen.py
+++ b/Koo/Screen/Screen.py
@@ -330,6 +330,9 @@ class Screen(QScrollArea):
         self.activated.emit()
 
     def close(self):
+        # @xtorello @xbarnada TODO revisar si hi ha canvis pendents d'aplicar abans de tancar
+        ## veure FormWidget.canClose / modifiedSave
+        print ("tancant")
         self.closed.emit()
 
     # @brief Searches with the current parameters of the search form and loads the

--- a/tests/test_qt5.py
+++ b/tests/test_qt5.py
@@ -35,14 +35,15 @@ class TestWindow(QMainWindow):
 win = TestWindow()
 
 class KooApi(Api.KooApi):
-	def execute(self, actionId, data={}, type=None, context={}):
-		Koo.Actions.execute( actionId, data, type, context )
+    def execute(self, actionId, data={}, type=None, context={}):
+    	Koo.Actions.execute( actionId, data, type, context )
 
-	def executeReport(self, name, data={}, context={}):
-		return Koo.Actions.executeReport( name, data, context )
+    def executeReport(self, name, data={}, context={}):
+    	return Koo.Actions.executeReport( name, data, context )
 
-	def executeAction(self, action, data={}, context={}):
-		Koo.Actions.executeAction( action, data, context )
+    def executeAction(self, action, data={}, context={}):
+        pass
+    	# Koo.Actions.executeAction( action, data, context )
 
 	def executeKeyword(self, keyword, data={}, context={}):
 		return Koo.Actions.executeKeyword( keyword, data, context )


### PR DESCRIPTION
It extends the UI to add two buttons for any view.

Concretelly adds the "Save" and "Cancel" buttons, with tunned icons that dispatch the related global save() and cancel() methods.

Fix #14 Add Save and Cancel buttons at actions level 