### PR TITLE
Handle parent save cancel

### DIFF
--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -146,6 +146,8 @@ class ActionFactory:
             'type': 'ir.actions.report.xml'
         })
 
+        parent_widget = parent.parentWidget()
+
         # Save action
         definition['action'].append({
             'name': 'save',

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -117,11 +117,12 @@ class Action(QAction):
         Plugins.execute(self._data, self._model,
                         currentId, selectedIds, context)
 
+def dummy_method(self):
+    pass
+
 # @brief The ActionFactory class is a factory that creates Action objects to execute
 # actions on the server. Typically those shown in the toolbar and menus for an specific
 # model
-
-
 class ActionFactory:
     # @brief Creates a list of Action objects given a parent, model and definition.
     #
@@ -129,6 +130,7 @@ class ActionFactory:
     # fields_view_get.
     @staticmethod
     def create(parent, definition, model):
+
         if not definition:
             # If definition is not set we initialize it appropiately
             # to be able to add the 'Print Screen' action.
@@ -147,18 +149,19 @@ class ActionFactory:
         })
 
         parent_widget = parent.parentWidget()
+        print (model, parent, parent.parentWidget())
 
         # Handle cancel method
         try:
             save_method = parent_widget.save
         except:
-            save_method = None
+            save_method = dummy_method
 
         # Handle cancel method
         try:
             cancel_method = parent_widget.cancel
         except:
-            cancel_method = None
+            cancel_method = dummy_method
 
         # Save action
         definition['action'].append({
@@ -198,6 +201,7 @@ class ActionFactory:
                     action.setIcon(QIcon(":/images/{}.png".format(tool['name'])))
                     if tool['action'] is not None:
                         action.triggered.connect(tool['action'])
+
 
                 else:
                     if number > 9:

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -148,12 +148,18 @@ class ActionFactory:
 
         parent_widget = parent.parentWidget()
 
+        # Handle cancel method
+        try:
+            save_method = parent_widget.save
+        except:
+            save_method = None
+
         # Save action
         definition['action'].append({
             'name': 'save',
             'string': _('Save'),
             'shortcut': 'S',
-            'action': parent.parentWidget().save,
+            'action': save_method,
         })
 
         # Cancel action

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -154,6 +154,12 @@ class ActionFactory:
         except:
             save_method = None
 
+        # Handle cancel method
+        try:
+            cancel_method = parent_widget.save
+        except:
+            cancel_method = None
+
         # Save action
         definition['action'].append({
             'name': 'save',
@@ -167,7 +173,7 @@ class ActionFactory:
             'name': 'cancel',
             'string': _('Cancel'),
             'shortcut': 'C',
-            'action': parent.parentWidget().cancel,
+            'action': cancel_method,
         })
 
         actions = []

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -196,7 +196,8 @@ class ActionFactory:
                     action.setShortcut(QKeySequence(shortcut))
                     action.setToolTip(action.text() + ' (%s)' % shortcut)
                     action.setIcon(QIcon(":/images/{}.png".format(tool['name'])))
-                    action.triggered.connect(tool['action'])
+                    if tool['action'] is not None:
+                        action.triggered.connect(tool['action'])
 
                 else:
                     if number > 9:

--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -156,7 +156,7 @@ class ActionFactory:
 
         # Handle cancel method
         try:
-            cancel_method = parent_widget.save
+            cancel_method = parent_widget.cancel
         except:
             cancel_method = None
 


### PR DESCRIPTION
This bypass the exception related to lack of save/cancel method for *tomany elements.

With this, the view can be rendered, and the widgets can be used.

The data is still not updated to db while save is requested, see #22.

Fix #27 Can't open Search dialog of Many2Many