### PR TITLE
Add new RPC.Client

### DIFF
--- a/Koo/Rpc/Client.py
+++ b/Koo/Rpc/Client.py
@@ -1,0 +1,5 @@
+import erppeek
+
+class Client(object):
+    def __new__(cls, session):
+        return erppeek.Client(session.url, session.databaseName, session.userName, session.password)

--- a/Koo/Rpc/__init__.py
+++ b/Koo/Rpc/__init__.py
@@ -28,4 +28,4 @@
 from .Rpc import *
 from .Cache import *
 from .Subscriber import *
-
+from .Client import Client


### PR DESCRIPTION
To provide an erppeek.Client interface based on current session

WIP to improve Clients generation reusing current RPC session if
stablished (instead of create a new client for each req)

Now it just works and provides peek syntax

Todo:
- fix client generation
- fix rpc service patching
- inject current session context to peek

Fix #43 Provide basic Rpc.Client 