### PR TITLE
Fix current Record on 2many

### DIFF
--- a/Koo/View/Tree/TreeView.py
+++ b/Koo/View/Tree/TreeView.py
@@ -289,6 +289,7 @@ class TreeView(AbstractView):
         if self.selecting:
             return
         self.currentRecord = self.treeModel.recordFromIndex(current)
+        self.screen.setCurrentRecord(self.currentRecord)
         # We send the current record. Previously we sent only the id of the model, but
         # new models have id=None
         # self.currentChanged.emit(self.currentRecord)


### PR DESCRIPTION
# Description
- Sets the `currentRecord` on the Screen to fix the selected element of the 2many