### PR TITLE
Fix progress widge

### DIFF
--- a/Koo/Fields/ProgressBar/ProgressBar.py
+++ b/Koo/Fields/ProgressBar/ProgressBar.py
@@ -82,7 +82,8 @@ class ProgressBarFieldDelegate(AbstractFieldDelegate):
         opts.minimum = 1
         opts.maximum = 100
         opts.textVisible = True
-        percent, ok = index.data(Qt.DisplayRole).toDouble()
+        value = index.data(Qt.DisplayRole)
+        percent = float(value.split(",")[0])
         percent = max(min(percent, 100), 0)
         opts.progress = percent
         opts.text = QString('%d%%' % percent)


### PR DESCRIPTION
# Description
- Fixes the progress widget

# Before
![image](https://user-images.githubusercontent.com/2422305/42993617-1a7a49a4-8c0c-11e8-888a-e1d2fdd438f9.png)

# After
![image](https://user-images.githubusercontent.com/2422305/42993576-fdeb5418-8c0b-11e8-8f5e-33918a493f6b.png)

# Why
- The value now is returned as a str from `index.data`