### PR TITLE
Fix many2one setData

### DIFF
--- a/Koo/Fields/ManyToOne/ManyToOne.py
+++ b/Koo/Fields/ManyToOne/ManyToOne.py
@@ -490,7 +490,7 @@ class ManyToOneFieldDelegate(AbstractFieldDelegate):
             model.setValue(self.name, False)
             return
 
-        if str(kooModel.data(index, Qt.DisplayRole).toString()) == str(editor.text()):
+        if str(kooModel.data(index, Qt.DisplayRole).value()) == str(editor.text()):
             return
 
         domain = model.domain(self.name)


### PR DESCRIPTION
# Description
- Fixes the `setData` of the Many2One

# Why 
- With pyqt5 the Qvariant has no .toString