### PR TITLE
Fix concurrent edit message box

### DIFF
--- a/Koo/Dialogs/FormWidget.py
+++ b/Koo/Dialogs/FormWidget.py
@@ -588,8 +588,7 @@ class FormWidget(QWidget, FormWidgetUi):
             value = QMessageBox.question(
                 self, _('Question'),
                 _('<p>You have modified the following fields in current record:</p>%s<p>Do you want to save the changes?</p>') % fields,
-                QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
-                2, 2)
+                QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel)
             if value == 0:
                 return self.save()
             elif value == 1:


### PR DESCRIPTION
# Description
- Fixes the message box when edit concurrently on the same model

# Why
- On PyQt5 the message box syntax has changed and should use the `QMessageBox.x`