### PR TITLE
Fix selection edition

### DIFF
--- a/Koo/Fields/Selection/Selection.py
+++ b/Koo/Fields/Selection/Selection.py
@@ -133,7 +133,7 @@ class SelectionFieldDelegate(AbstractFieldDelegate):
         return widget
 
     def setEditorData(self, editor, index):
-        value = index.data(Qt.EditRole).toString()
+        value = index.data(Qt.EditRole)
         editor.setCurrentIndex(editor.findText(value))
 
     def setModelData(self, editor, model, index):


### PR DESCRIPTION
# Description
- Fixes selection edition

# Why
- The `index.data(Qt.EditRole)` returns a str so the .toString() is not required