### PR TITLE
Avoid reserved words

### DIFF
--- a/Koo/Fields/Selection/Selection.py
+++ b/Koo/Fields/Selection/Selection.py
@@ -128,8 +128,8 @@ class SelectionFieldDelegate(AbstractFieldDelegate):
         widget = QComboBox(parent)
         widget.setEditable(False)
         widget.setInsertPolicy(QComboBox.InsertAtTop)
-        for (id, name) in self.attributes.get('selection', []):
-            widget.addItem(name, QVariant(id))
+        for (ident, name) in self.attributes.get('selection', []):
+            widget.addItem(name, QVariant(ident))
         return widget
 
     def setEditorData(self, editor, index):


### PR DESCRIPTION
# Descrition 
- Avoid using reserved word `id`