### PR TITLE
Fix the expression comparsion

### DIFF
--- a/Koo/Rpc/Rpc.py
+++ b/Koo/Rpc/Rpc.py
@@ -672,7 +672,8 @@ class Session:
             context = {}
         context['uid'] = self.uid
         if isinstance(expression, str):
-            expression = expression.replace("'active_id'", "active_id")
+            if "'active_id'" in expression:
+                expression = expression.replace("'active_id'", "active_id")
             return eval(expression, context)
         else:
             return expression


### PR DESCRIPTION
# Description 
- Fixes the expression when "'active_id'" is in the expression

# Why
- If the `active_id` key it's not in the expression the raises a key error