### PR TITLE
Fix the load of one2may fields

### DIFF
--- a/Koo/Screen/Action.py
+++ b/Koo/Screen/Action.py
@@ -212,7 +212,8 @@ class ActionFactory:
             'type': 'ir.actions.report.xml'
         })
         fwidget = parent.parentWidget()
-        if not fwidget.isReadonly():
+        hasReadonly = getattr(fwidget, "isReadonly", None)
+        if hasReadonly and not fwidget.isReadonly():
             # Save action
             definition['action'].append({
                 'name': 'save',


### PR DESCRIPTION
# Description
- Checks the widget has the method isReadonly before to use it