### PR TITLE
Add 'no_bbox_search' flag to context if 'session' exist on the context on Many2One search

### DIFF
--- a/Koo/Fields/ManyToOne/ManyToOne.py
+++ b/Koo/Fields/ManyToOne/ManyToOne.py
@@ -238,6 +238,8 @@ class ManyToOneFieldWidget(AbstractFieldWidget, ManyToOneFieldWidgetUi):
         """
         domain = self.record.domain(self.name)
         context = self.record.fieldContext(self.name)
+        if 'session' in context:
+            context.update({'no_bbox_search': True})
         ids = Rpc.session.execute(
             '/object', 'execute', self.attrs['relation'], 'name_search', name, domain, 'ilike', context, False)
         if ids and len(ids) == 1:


### PR DESCRIPTION
# Objective
Add 'no_bbox_search' flag to context if 'session' exist on the context on Many2One search.

# Fixes
When you search a SessionManaged object with the Many2One widget in a Koo form, if we are working on a Session, only the elements contained on the Session Bounding Box are listed. With this PR we add a flag to the context that will let the ERP know when it have to skip the Session Bounding Box constrain. 

