### PR TITLE
Avoid popup error dialog when create is denied

### DIFF
--- a/Koo/Dialogs/FormWidget.py
+++ b/Koo/Dialogs/FormWidget.py
@@ -443,6 +443,12 @@ class FormWidget(QWidget, FormWidgetUi):
                 if not modification and Settings.value('koo.auto_new'):
                     self.screen.new()
                 QApplication.restoreOverrideCursor()
+            # This condition is an ugly patch to avoid popup error msg, the real
+            # fix must be find why the Koo tries to create the record on the
+            # ERP-Side
+            elif not self.screen.currentRecord().invalidFields:
+                QApplication.restoreOverrideCursor()
+                ident = False
             else:
                 self.updateStatus(_('<font color="red">Invalid form</font>'))
 


### PR DESCRIPTION
For some reason Koo tries to recreate an existing elements when you press save. From the ERP we avoid creating this elements when it happens. 
This PR avoids the ERROR-Popup in this situations on the Koo-Side.