### PR TITLE
Raise the errors on form creation

### DIFF
--- a/Koo/Dialogs/WindowService.py
+++ b/Koo/Dialogs/WindowService.py
@@ -71,7 +71,7 @@ def createWindow(view_ids, model, res_id=False, domain=None,
                                 context=context, name=name, readonly=readonly)
         except Rpc.RpcException as e:
             QApplication.restoreOverrideCursor()
-            return
+            raise e
         if target == 'new':
             widget.setStatusBarVisible(False)
         widget.setAutoReload(autoReload)
@@ -95,7 +95,7 @@ def createWindow(view_ids, model, res_id=False, domain=None,
             win = TreeWidget(view, model, domain, context, name=name)
         except Rpc.RpcException as e:
             QApplication.restoreOverrideCursor()
-            return
+            raise e
         QApplication.restoreOverrideCursor()
         Api.instance.windowCreated(win, target)
     else:


### PR DESCRIPTION
This PR is made to help Qgisce to handle the ERP errors that happens while we are opening an element view.
Before this change Qgisce did not notice if the form generation was succesfull or failed.

THIS PR IS REQUIRED BY: https://github.com/gisce/qgisce/pull/91
