### PR TITLE
Handle case when geom in form.

### DIFF
--- a/Koo/Model/Record.py
+++ b/Koo/Model/Record.py
@@ -378,7 +378,10 @@ class Record(QObject):
                 context = self.context()
                 fill_geom = (
                     'geom' in context and
-                    'geom' not in values and
+                    (
+                        'geom' not in values or
+                        ('geom' in values and not values.get('geom', True))
+                    ) and
                     'geom' in self.rpc.fields_get()
                 )
                 if fill_geom:


### PR DESCRIPTION
Handle case when geom in form and it's False. It should always be filled.
