### PR TITLE
Fix the ReferenceFieldWidget.

### DIFF
--- a/Koo/Fields/Reference/ReferenceFieldWidget.py
+++ b/Koo/Fields/Reference/ReferenceFieldWidget.py
@@ -170,14 +170,12 @@ class ReferenceFieldWidget(AbstractFieldWidget, ReferenceFieldWidgetUi):
         self.search()
 
     def new(self):
-        resource = str(self.uiModel.itemData(
-            self.uiModel.currentIndex()).toString())
+        resource = self.uiModel.itemData(self.uiModel.currentIndex())
         dialog = ScreenDialog(self)
         dialog.setup(resource)
         dialog.setAttributes(self.attrs)
         if dialog.exec_() == QDialog.Accepted:
-            resource = str(self.uiModel.itemData(
-                self.uiModel.currentIndex()).toString())
+            resource = self.uiModel.itemData(self.uiModel.currentIndex())
             self.record.setValue(self.name, (resource, dialog.record))
 
     def open(self):


### PR DESCRIPTION
Fix the ReferenceFieldWidge since it tries to execute a method that no exist for the type `str`.
The type of the return value of the above line `self.uiModel.itemData(self.uiModel.currentIndex())` it's now a of type `str` so it's impossible to call the method `toString()`.
