### PR TITLE
Fix añadir elementos many2many QGIS

### DIFF
--- a/Koo/Fields/ManyToMany/ManyToMany.py
+++ b/Koo/Fields/ManyToMany/ManyToMany.py
@@ -184,7 +184,7 @@ class ManyToManyFieldWidget(AbstractFieldWidget, ManyToManyFieldWidgetUi):
         # This is not necessary in case of removing an item.
         # Maybe a better option should be found. But this one works just right.
         self.screen.group.recordChanged(None)
-        self.screen.group.recordModified(None)
+        self.screen.group.recordModified(None, True)
 
     def remove(self):
         # As the 'remove' button modifies the model we need to be sure all other fields/widgets

--- a/Koo/Fields/ManyToMany/ManyToMany.py
+++ b/Koo/Fields/ManyToMany/ManyToMany.py
@@ -193,6 +193,9 @@ class ManyToManyFieldWidget(AbstractFieldWidget, ManyToManyFieldWidgetUi):
         self.view.store()
         self.screen.remove()
         self.screen.display()
+        self.uiText.clear()
+        self.screen.group.recordChanged(None)
+        self.screen.group.recordModified(None, True)
 
     def setReadOnly(self, value):
         AbstractFieldWidget.setReadOnly(self, value)

--- a/Koo/Model/Group.py
+++ b/Koo/Model/Group.py
@@ -496,6 +496,7 @@ class RecordGroup(QObject):
             self.recordChangedSignal.emit(self.parent)
 
     def recordModified(self, record, many2many=False):
+        # whole group marked as modified when adding/removing items in many2many
         if many2many:
             self._modified = True
         if self._signalsEnabled:

--- a/Koo/Model/Group.py
+++ b/Koo/Model/Group.py
@@ -69,6 +69,7 @@ class RecordGroup(QObject):
     recordsRemoved = pyqtSignal(int, int)
     recordChangedSignal = pyqtSignal('PyQt_PyObject')
     # recordChanged = pyqtSignal(QObject)
+    _modified = False
     modified = pyqtSignal()
     # @xtorello toreview signal int type
     sorting = pyqtSignal(int)
@@ -494,7 +495,9 @@ class RecordGroup(QObject):
         if self.parent:
             self.recordChangedSignal.emit(self.parent)
 
-    def recordModified(self, record):
+    def recordModified(self, record, many2many=False):
+        if many2many:
+            self._modified = True
         if self._signalsEnabled:
             self.modified.emit()
         if self.parent:
@@ -1195,6 +1198,8 @@ class RecordGroup(QObject):
         :return: True if any of the records in the group has been modified.
         :rtype: bool
         """
+        if self._modified:
+            return True
         for record in self.records:
             if isinstance(record, Record):
                 if record.isModified():

--- a/Koo/Model/Record.py
+++ b/Koo/Model/Record.py
@@ -211,7 +211,7 @@ class Record(QObject):
         for key_name, value in self.values.items():
             from .Group import RecordGroup
             if isinstance(value, RecordGroup):
-                if value.modified:
+                if value.isModified():
                     mod = True
         return mod
 

--- a/Koo/Model/Record.py
+++ b/Koo/Model/Record.py
@@ -211,7 +211,7 @@ class Record(QObject):
         for key_name, value in self.values.items():
             from .Group import RecordGroup
             if isinstance(value, RecordGroup):
-                if value.isModified():
+                if value.modified:
                     mod = True
         return mod
 


### PR DESCRIPTION
## Objetivos

- Poder añadir elementos a una relación `many2many` desde el `QGIS`
- De esta manera, se reconoce el elemento como modificado y se registran los cambios en la sesión en `giscegis_session_changes`

## Relacionado

- https://github.com/gisce/erp/pull/18732

## Capturas de pantalla
### Antes
[Enregistrament de pantalla des de 5-12-23 14:07:52.webm](https://github.com/gisce/openerp-client-kde/assets/118173541/30888002-d52b-4707-aec7-151dbcdeac55)
### Después
[Enregistrament de pantalla des de 5-12-23 14:09:09.webm](https://github.com/gisce/openerp-client-kde/assets/118173541/8d9e74c2-9479-4386-ad05-b3118a631806)
### Cliente KDE
[Enregistrament de pantalla des de 20-12-23 11:38:15.webm](https://github.com/gisce/openerp-client-kde/assets/118173541/f79707a6-155f-459d-b631-0647da151c14)

## Checklist

- [x] Test code
- [x] Screenshots