### PR TITLE
Fix filtrar campos selection y reference en el QGIS

### DIFF
--- a/Koo/Search/Reference/ReferenceSearchWidget.py
+++ b/Koo/Search/Reference/ReferenceSearchWidget.py
@@ -52,8 +52,7 @@ class ReferenceSearchWidget(AbstractSearchWidget, ReferenceSearchWidgetUi):
             self.invertedModels[i] = j
 
     def value(self):
-        resource = str(self.uiModel.itemData(
-            self.uiModel.currentIndex()).toString())
+        resource = self.uiModel.itemData(self.uiModel.currentIndex())
         if resource:
             return [(self.name, 'like', resource + ',')]
         else:

--- a/Koo/Search/Selection/SelectionSearchWidget.py
+++ b/Koo/Search/Selection/SelectionSearchWidget.py
@@ -56,8 +56,8 @@ class SelectionSearchWidget(AbstractSearchWidget):
     def value(self):
         value = self.uiCombo.itemData(self.uiCombo.currentIndex())
 
-        if value and value.isValid():
-            return [(self.name, '=', str(value.toString()))]
+        if value:
+            return [(self.name, '=', value)]
         else:
             return []
 


### PR DESCRIPTION
## Objetivos

- Corregir un bug que no permitía filtrar ni por campos selection ni por campos de tipo reference desde el QGIS

## Relacionado

- https://github.com/gisce/qgisce/pull/122

## Capturas de pantalla
[Enregistrament de pantalla des de 11-3-24 13:47:22.webm](https://github.com/gisce/openerp-client-kde/assets/118173541/b460f765-c716-41b0-8d84-a7776d40159d)

## Checklist

- [x] Test code
- [x] Screenshots