### PR TITLE
Fallback graceful a widget por defecto para widgets desconocidos

### DIFF
--- a/Koo/Fields/FieldWidgetFactory.py
+++ b/Koo/Fields/FieldWidgetFactory.py
@@ -26,7 +26,10 @@
 ##############################################################################
 
 from Koo.Common import Plugins
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 # @brief The FieldWidgetFactory class specializes in creating the appropiate
 # widget for a given type.
@@ -45,17 +48,29 @@ class FieldWidgetFactory:
         Plugins.scan('Koo.Fields', os.path.abspath(os.path.dirname(__file__)))
 
     # @brief Creates a new widget given type, parent and attributes.
+    # @param fallback_type: field type to use if widgetType is not registered.
     @staticmethod
-    def create(widgetType, parent, view, attributes):
+    def create(widgetType, parent, view, attributes, fallback_type=None):
         FieldWidgetFactory.scan()
 
         # We do not support relational fields treated as selection ones
         if widgetType == 'selection' and 'relation' in attributes:
             widgetType = 'many2one'
 
-        if not widgetType in FieldWidgetFactory.widgets:
-            print("Widget '%s' not available" % widgetType)
-            return None
+        if widgetType not in FieldWidgetFactory.widgets:
+            if fallback_type and fallback_type in FieldWidgetFactory.widgets:
+                logger.warning(
+                    "Widget '%s' not available, falling back to field type '%s'",
+                    widgetType, fallback_type
+                )
+                # Fix the type in attributes so the fallback widget initialises correctly
+                attributes['type'] = fallback_type
+                # indicator-like widgets are display-only — force readonly
+                attributes['readonly'] = True
+                widgetType = fallback_type
+            else:
+                logger.warning("Widget '%s' not available", widgetType)
+                return None
 
         widgetClass = FieldWidgetFactory.widgets[widgetType]
         return widgetClass(parent, view, attributes)

--- a/Koo/Model/Field.py
+++ b/Koo/Model/Field.py
@@ -562,12 +562,19 @@ class FieldFactory:
         if fieldType == 'selection' and 'relation' in attributes:
             fieldType = 'many2one'
 
-        if fieldType == "one2many" or fieldType == "many2many":
-            return FieldFactory.types[fieldType](parent,attributes)
+        # If the widget type overrides the field type (e.g. 'indicator') and it
+        # is unknown, fall back to original_type stored by Screen._parse_fields
+        # so the model handles field values correctly.
+        if fieldType not in FieldFactory.types:
+            original_type = attributes.get('original_type')
+            if original_type and original_type in FieldFactory.types:
+                fieldType = original_type
+            else:
+                return FieldFactory.types['char'](parent, attributes)
 
-        if fieldType in FieldFactory.types:
+        if fieldType == "one2many" or fieldType == "many2many":
             return FieldFactory.types[fieldType](parent, attributes)
-        else:
-            return FieldFactory.types['char'](parent, attributes)
+
+        return FieldFactory.types[fieldType](parent, attributes)
 
 # vim:noexpandtab:

--- a/Koo/Screen/Screen.py
+++ b/Koo/Screen/Screen.py
@@ -658,6 +658,10 @@ class Screen(QScrollArea):
                 if attrs.get('widget', False):
                     if attrs['widget'] == 'one2many_list':
                         attrs['widget'] = 'one2many'
+                    # Preserve original field type before overwriting with widget name
+                    original_type = fields.get(attrs.get('name', ''), {}).get('type')
+                    if original_type:
+                        attrs['original_type'] = original_type
                     attrs['type'] = attrs['widget']
                 try:
                     fields[attrs['name']].update(attrs)

--- a/Koo/View/Form/Parser.py
+++ b/Koo/View/Form/Parser.py
@@ -227,13 +227,17 @@ class FormParser(AbstractParser):
                     continue
                 name = attrs['name']
                 del attrs['name']
-                type = attrs.get('widget', fields[name]['type'])
+                field_type = fields[name].get('original_type') or fields[name]['type']
+                type = attrs.get('widget', field_type)
                 fields[name].update(attrs)
                 fields[name]['model'] = self.viewModel
 
-                # Create the appropiate widget for the given field type
+                # Create the appropiate widget for the given field type.
+                # Pass field_type as fallback so unknown widget= hints
+                # degrade gracefully to the default widget for the field.
                 widget = FieldWidgetFactory.create(
-                    type, container, self.view, fields[name])
+                    type, container, self.view, fields[name],
+                    fallback_type=field_type)
                 if not widget:
                     continue
 

--- a/Koo/View/Svg/Parser.py
+++ b/Koo/View/Svg/Parser.py
@@ -52,13 +52,17 @@ class SvgParser(AbstractParser):
             if node.localName == 'field':
                 attributes = Common.nodeAttributes(node)
                 name = attributes['name']
-                type = attributes.get('widget', fields[name]['type'])
+                field_type = fields[name].get('original_type') or fields[name]['type']
+                type = attributes.get('widget', field_type)
                 fields[name].update(attributes)
                 fields[name]['model'] = viewModel
 
-                # Create the appropiate widget for the given field type
+                # Create the appropiate widget for the given field type.
+                # Pass field_type as fallback so unknown widget= hints
+                # degrade gracefully to the default widget for the field.
                 widget = FieldWidgetFactory.create(
-                    type, None, self.view, fields[name])
+                    type, None, self.view, fields[name],
+                    fallback_type=field_type)
                 if not widget:
                     continue
                 self.view.widgets[name] = widget

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ Topic :: Office/Business
 
 setup(
     name='koo',
-    version='6.6.3',
+    version='6.6.4',
     packages=find_packages(),
     url='http://www.NaN-tic.com/koo-platform',
     license='GPL',


### PR DESCRIPTION
## Descripción

Cuando las vistas ERP contienen campos con `widget=` que el cliente Koo no reconoce (p.ej. `indicator`, `switch`, `tag`, `steps`, `alert`, `markdown` del webclient), el widget se descartaba silenciosamente y el campo no aparecía en el formulario.

Ahora se utiliza el widget por defecto del tipo real del campo (read-only), permitiendo visualizar el valor hasta que se dé cobertura completa con PySide6.

## Cambios

- **`Screen._parse_fields`**: guarda `original_type` en el diccionario de atributos antes de sobreescribir `type` con el nombre del widget
- **`FieldFactory.create`**: usa `original_type` cuando el tipo no es conocido, para crear el field object correcto en el modelo (p.ej. `ManyToOneField` en lugar de `StringField`)
- **`FieldWidgetFactory.create`**: nuevo parámetro `fallback_type`; si el widget no existe pero el tipo base sí, lo utiliza como fallback (forzando `readonly=True` y `type=fallback_type`)
- **`Form/Parser` y `Svg/Parser`**: pasan `original_type` como `fallback_type`
- Sustituye `print()` por `logger.warning()` a `FieldWidgetFactory`

## Versión

6.6.3 → **6.6.4**