### PR TITLE
Añadir workflows de release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 6.6.4
+commit = False
+tag = False
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: OPENERP-CLIENT-KDE-RELEASE
+
+on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+        with:
+          strip_v: false
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
+          generate_release_notes: true

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,67 @@
+name: OPENERP-CLIENT-KDE-VERSION
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [ master ]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        contains(toJson(github.event.pull_request.labels.*.name), 'major') ||
+        contains(toJson(github.event.pull_request.labels.*.name), 'minor') ||
+        contains(toJson(github.event.pull_request.labels.*.name), 'patch')
+      )
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.PUB_MASTER_PUSH_TOKEN || github.token }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Setup git
+        run: |
+          git config --global user.email "devel@gisce.net"
+          git config --global user.name "giscegit"
+      - name: Install python packages
+        run: pip install bump2version
+      - name: Bump version, tag, and create release
+        env:
+          GH_TOKEN: ${{ secrets.PUB_MASTER_PUSH_TOKEN || github.token }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          VERSION_TYPE=false
+          if echo "$PR_LABELS" | jq -e 'index("major")' >/dev/null; then
+            VERSION_TYPE="major"
+          elif echo "$PR_LABELS" | jq -e 'index("minor")' >/dev/null; then
+            VERSION_TYPE="minor"
+          elif echo "$PR_LABELS" | jq -e 'index("patch")' >/dev/null; then
+            VERSION_TYPE="patch"
+          fi
+
+          if [[ "$VERSION_TYPE" == false ]]; then
+            exit 0
+          fi
+
+          bump2version "$VERSION_TYPE"
+          NEW_VERSION=$(python setup.py --version)
+          git add setup.py .bumpversion.cfg
+          git commit -m "Bump to v${NEW_VERSION}"
+          git tag "v${NEW_VERSION}"
+          git push origin master "v${NEW_VERSION}"
+          gh release create "v${NEW_VERSION}" --generate-notes --title "v${NEW_VERSION}" || \
+            gh release view "v${NEW_VERSION}"


### PR DESCRIPTION
## Resumen

Añade automatización de release para openerp-client-kde, que era el único repo del grupo revisado sin workflows de release.

- añade .bumpversion.cfg para versionar setup.py
- crea tag y GitHub Release al mergear una PR con label major, minor o patch
- crea GitHub Release también cuando se empuja manualmente un tag vX.Y.Z o vX.Y.Z-rcN

## Validación

- YAML parse OK para los workflows añadidos
- git diff --check OK
- python3 setup.py --version -> 6.6.4

Nota: no se añade build sdist al release porque el packaging legacy actual falla en sdist dry-run; el cambio se limita a crear release/tag sin abrir ese melón.